### PR TITLE
Änderungen am TEI

### DIFF
--- a/src/de/reisetagebuch-1.xml
+++ b/src/de/reisetagebuch-1.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de" n="1">
    <teiHeader>
       <fileDesc>
          <titleStmt>
@@ -45,7 +45,7 @@
                         <persName ref="gfa-actors-35">Johann Conrad Fischer</persName>, Kantonsrath und Artillerie-Oberstlieutenant.
                   <lb/> <placeName ref="gfa-places-131">Schaffhausen</placeName>, <date when="1844-11-26">26. Nov. 1844</date>.<note>Das Tagebuch wurde 1845 bei <persName ref="gfa-actors-1128">Franz Hurter</persName> in Schaffhausen gedruckt.</note></salute>
          </div>
-            <div type="preface">
+
                <div type="day">
                <head>Jugend und Ausbildung</head>
                   <p>Vorwort.</p>
@@ -257,7 +257,6 @@
          <pb n="57" facs="https://www.e-rara.ch/ebs/content/zoom/16618153"/>
          <pb n="58" facs="https://www.e-rara.ch/ebs/content/zoom/16618154"/>
          <pb n="59" facs="https://www.e-rara.ch/ebs/content/zoom/16618155"/>
-      </div>
       </body>
    </text>
 </TEI>

--- a/src/de/reisetagebuch-2.xml
+++ b/src/de/reisetagebuch-2.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de" n="2">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/src/de/reisetagebuch-3.xml
+++ b/src/de/reisetagebuch-3.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de" n="3">
     <teiHeader>
         <fileDesc>
             <titleStmt>

--- a/src/de/reisetagebuch-4.xml
+++ b/src/de/reisetagebuch-4.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de" n="4">
     <teiHeader>
         <fileDesc>
             <titleStmt>

--- a/src/de/reisetagebuch-7.xml
+++ b/src/de/reisetagebuch-7.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" lang="de" n="7">
     <teiHeader>
         <fileDesc>
             <titleStmt>

--- a/src/en/traveljournal-1.xml
+++ b/src/en/traveljournal-1.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" n="1">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/src/en/traveljournal-7.xml
+++ b/src/en/traveljournal-7.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en" n="7">
     <teiHeader>
         <fileDesc>
             <titleStmt>

--- a/src/html-pages/about-de.html
+++ b/src/html-pages/about-de.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Über die Edition</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Über die Edition</h1>
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Über die Edition</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/about-en.html
+++ b/src/html-pages/about-en.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Über die Edition</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Über die Edition</h1>
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Über die Edition</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/bibliography-de.html
+++ b/src/html-pages/bibliography-de.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Bibliografie</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Bibliografie</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Bibliografie</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/bibliography-en.html
+++ b/src/html-pages/bibliography-en.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Bibliografie</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Bibliografie</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Bibliografie</h1>            
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/citation-de.html
+++ b/src/html-pages/citation-de.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Zitiervorschlag</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Zitiervorschlag</h1>
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Zitiervorschlag</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/citation-en.html
+++ b/src/html-pages/citation-en.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Zitiervorschlag</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Zitiervorschlag</h1>
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Zitiervorschlag</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/editorial-guidelines-de.html
+++ b/src/html-pages/editorial-guidelines-de.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Editionsrichtlinien</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Editionsrichtlinien</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Editionsrichtlinien</h1>            
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/editorial-guidelines-en.html
+++ b/src/html-pages/editorial-guidelines-en.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Editionsrichtlinien</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Editionsrichtlinien</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Editionsrichtlinien</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/gdpr-de.html
+++ b/src/html-pages/gdpr-de.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Datenschutz</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Datenschutz</h1>
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Datenschutz</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/gdpr-en.html
+++ b/src/html-pages/gdpr-en.html
@@ -1,20 +1,7 @@
 
-<html>
-    <head>
-        <title>Datenschutz</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Datenschutz</h1>
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Datenschutz</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/impressum-de.html
+++ b/src/html-pages/impressum-de.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Impressum</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Impressum</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Impressum</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/impressum-en.html
+++ b/src/html-pages/impressum-en.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Impressum</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Impressum</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Impressum</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/thank-you-de.html
+++ b/src/html-pages/thank-you-de.html
@@ -1,19 +1,7 @@
-<html>
-    <head>
-        <title>Dank</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Dank</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
 
-    </body>
-</html>
+<main>
+    <h1>Dank</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/html-pages/thank-you-en.html
+++ b/src/html-pages/thank-you-en.html
@@ -1,19 +1,6 @@
-<html>
-    <head>
-        <title>Dank</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"/>        
-    </head>
-    <body>
-        <header>
-            <h1>Dank</h1>            
-        </header>
-        <main>
-            <h2>Überschrift 2</h2>
-            <p>Test zu Überschrift 2</p>
-            <p>....</p>
-        </main>
-        <footer/>        
-
-    </body>
-</html>
+<main>
+    <h1>Dank</h1>
+    <h2>Überschrift 2</h2>
+    <p>Test zu Überschrift 2</p>
+    <p>....</p>
+</main>

--- a/src/wip/reisetagebuch-5.xml
+++ b/src/wip/reisetagebuch-5.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de" n="5">
     <teiHeader>
         <fileDesc>
             <titleStmt>

--- a/src/wip/reisetagebuch-6.xml
+++ b/src/wip/reisetagebuch-6.xml
@@ -1,4 +1,4 @@
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="de" n="6">
     <teiHeader>
         <fileDesc>
             <titleStmt>


### PR DESCRIPTION
Dieser PR adressiert folgende Dinge: 

* Attribut 'n=<nummer>' auf tei:TEI hinzugefügt für alle Tagebücher hinzugefügt 
* fehlendes xml:lang hinzugefügt
* Anpassung der Struktur von tagebuch1 (en/de). Das `<div type="preface">` darf nicht um den ganzen Text gehen, was hier sicher auch nicht die Intention war, dieser fix führt dazu, dass dann auch https://github.com/GF-Corporate-Archives/gf-johann-conrad-fischer/issues/363 gefixt ist. 
* bitte sicherstellen, dass `<div type="preface">` für alle Tagebücher gleich genutzt wird, wenn möglich.